### PR TITLE
Fix harvest requests exceptions

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -42,8 +42,10 @@ class CKANHarvester(HarvesterBase):
 
         try:
             http_request = requests.get(url, headers=headers)
+        except HTTPError as e:
+            raise ContentFetchError('HTTP error: %s %s' % (e.response.status_code, e.request.url))
         except RequestException as e:
-            raise ContentFetchError('HTTP error: %s' % e.code)
+            raise ContentFetchError('Request error: %s' % e)
         except Exception as e:
             raise ContentFetchError('HTTP general exception: %s' % e)
         return http_request.text


### PR DESCRIPTION
We are currently getting a error `AttributeError: 'SSLError' object has no attribute 'code'`.  This changes the harvest exception handling so we can correctly log the error.