### PR TITLE
Rebase on CKAN trunk and add tests for error raise in _get_content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased_
 Fixed
 -----
 - harvest_source_type_exists validator should not fail if Harvester has no ``info()`` method #338
+- Fix SSL problems for old versions of Python 2.7.x #344
 
 *******************
 1.1.4_ - 2018-10-26

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_.
 ***********
 Unreleased_
 ***********
+Fixed
+-----
+- harvest_source_type_exists validator should not fail if Harvester has no ``info()`` method #338
 
 *******************
 1.1.4_ - 2018-10-26

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,13 +10,55 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_.
 ***********
 Unreleased_
 ***********
+
+*******************
+1.1.4_ - 2018-10-26
+*******************
+Fixed
+-----
+- Fix nav link
+
+*******************
+1.1.3_ - 2018-10-26
+*******************
+Fixed
+-----
+- Reduce usage of c vars (CKAN 2.9)
+
+*******************
+1.1.2_ - 2018-10-25
+*******************
 Added
 -----
-- Move CKANHarvester._last_error_free_job to HarvesterBase.last_error_free_job #305
+- Send harvest-error-mails to organization-admins #329
+- CKAN Harvester option to include/exclude groups #323
+- Use Redis password from configuration when present #332
+- Support for CKAN 2.9
 
 Fixed
 -----
-- Fix handling of `clean_tags` options for tag lists and dicts #304
+- Ensures the AND operator for fq in solr #335
+- Fix styling issues on Bootstrap 3
+
+*******************
+1.1.1_ - 2018-06-13
+*******************
+Added
+-----
+- Move CKANHarvester._last_error_free_job to HarvesterBase.last_error_free_job #305
+- Add the CSS classes for FontAwesome 4.x #313
+- Add config option for dataset name append type #327
+- Send error mail to admin when harvesting fails #244
+
+Changed
+-------
+- Readme test tip ckan parameter #318
+
+Fixed
+-----
+- Fix handling of ``clean_tags`` options for tag lists and dicts #304
+- Don't delete all solr documents/fail to index harvesters when harvest config blank #315
+- Fix print statements to be Py3 friendly #328
 
 *******************
 1.1.0_ - 2017-11-07
@@ -29,7 +71,7 @@ Changed
 -------
 - Test improvements for harvester config #288
 - Use package_search API for count of datasets #298
-- Catch sqlalchemy.exc.DatabaseError instead of sqlalchemy.exc.OperationalError in `gather_callback` #301
+- Catch sqlalchemy.exc.DatabaseError instead of sqlalchemy.exc.OperationalError in ``gather_callback`` #301
 
 Fixed
 -------
@@ -124,7 +166,11 @@ Categories
 - ``Fixed`` for any bug fixes.
 - ``Security`` to invite users to upgrade in case of vulnerabilities.
 
-.. _Unreleased: https://github.com/ckan/ckanext-harvest/compare/v1.1.0...HEAD
+.. _Unreleased: https://github.com/ckan/ckanext-harvest/compare/v1.1.4...HEAD
+.. _1.1.4: https://github.com/ckan/ckanext-harvest/compare/v1.1.3...v1.1.4
+.. _1.1.3: https://github.com/ckan/ckanext-harvest/compare/v1.1.2...v1.1.3
+.. _1.1.2: https://github.com/ckan/ckanext-harvest/compare/v1.1.1...v1.1.2
+.. _1.1.1: https://github.com/ckan/ckanext-harvest/compare/v1.1.0...v1.1.1
 .. _1.1.0: https://github.com/ckan/ckanext-harvest/compare/v1.0.0...v1.1.0
 .. _1.0.0: https://github.com/ckan/ckanext-harvest/compare/v0.0.5...v1.0.0
 .. _0.0.5: https://github.com/ckan/ckanext-harvest/compare/v0.0.4...v0.0.5

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -3,6 +3,7 @@ from requests.exceptions import RequestException
 
 import datetime
 from urllib3.contrib import pyopenssl
+import urllib
 
 from ckan import model
 from ckan.logic import ValidationError, NotFound, get_action

--- a/ckanext/harvest/logic/validators.py
+++ b/ckanext/harvest/logic/validators.py
@@ -113,7 +113,10 @@ def harvest_source_type_exists(value, context):
     # Get all the registered harvester types
     available_types = []
     for harvester in PluginImplementations(IHarvester):
-        info = harvester.info()
+        try:
+            info = harvester.info()
+        except AttributeError:
+            continue
         if not info or 'name' not in info:
             log.error('Harvester %s does not provide the harvester name in '
                       'the info response' % harvester)

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -574,6 +574,7 @@ def migrate_v3_create_datasets(source_ids=None):
             'source_type': source.type,
             'config': source.config,
             'frequency': source.frequency,
+            'owner_org': source.publisher_id,
             }
         context['message'] = 'Created package for harvest source {0}'.format(source.id)
         try:

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,9 +1,4 @@
 pika==0.9.8
 redis==2.10.1
 requests==2.20.0
-idna==2.7
-ndg-httpsclient==0.5.1
-pyasn1==0.4.4
 pyOpenSSL==18.0.0
-urllib3==1.23
-enum34==1.1.6

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.1.3'
+version = '1.1.4'
 
 setup(
     name='ckanext-harvest',


### PR DESCRIPTION
## What

This PR includes commits from the ckan trunk and 3 additional commits to fix a missing HTTPError import and add tests to for handling errors.

## How to review 

For expediency the main difference from the master trunk are the last 2 commits. 

All the tests are passing on ckan except for a failed test on master which is an issue on the ckan test frameworks latest master.