### PR TITLE
Add `Not modified` statistic report for unchanged imports.

### DIFF
--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -436,7 +436,7 @@ class Harvester(CkanCommand):
         # Determine the job
         try:
             job_dict = get_action('harvest_job_create')(
-                context, {'source_id': source['id']})
+                context, {'source_id': source['id'], 'run': False})
         except HarvestJobExists:
             running_jobs = get_action('harvest_job_list')(
                 context, {'source_id': source['id'], 'status': 'Running'})

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -426,7 +426,7 @@ def fetch_and_import_stages(harvester, obj):
         obj.import_finished = datetime.datetime.utcnow()
         if success_import:
             obj.state = "COMPLETE"
-            if success_import is 'unchanged':
+            if success_import == 'unchanged':
                 obj.report_status = 'not modified'
                 obj.save()
                 return

--- a/ckanext/harvest/templates/snippets/job_details.html
+++ b/ckanext/harvest/templates/snippets/job_details.html
@@ -25,7 +25,7 @@ Example:
       {% endif %}
       {{ _('errors') }}
     </span>
-    {% for action in ['added', 'updated', 'deleted'] %}
+    {% for action in ['added', 'updated', 'deleted', 'not modified'] %}
       <span class="label" data-diff="{{ action }}">
         {% if action in stats and stats[action] > 0 %}
           {{ stats[action] }}

--- a/ckanext/harvest/templates/source/job/list.html
+++ b/ckanext/harvest/templates/source/job/list.html
@@ -45,7 +45,7 @@
                   </span>
                 </li>
               {% endif %}
-              {% for action in ['added', 'updated', 'deleted'] %}
+              {% for action in ['added', 'updated', 'deleted', 'not modified'] %}
                 <li>
                   <span class="label" data-diff="{{ action }}" title="{{ _(action) }}">
                     {% if action in job.stats and job.stats[action] > 0 %}
@@ -66,4 +66,3 @@
 
 </div>
 {% endblock %}
-  


### PR DESCRIPTION
This PR adds a new report statistic badge for unchanged harvested imports. This will provide clearer information for users on how many datasets have been involved in a harvesting job.

Currently these stats reports have been unreliable as `CKANEXT-spatial` has been causing unchanged imports to be erroneously reported as deleted. This has been addressed in 
https://github.com/alphagov/ckanext-spatial/pull/8

The PR also prevents the `run_test` paster command from actually sending harvest jobs to the gathering queue. This ensures that running harvest jobs will succeed rather than being indefinitely queued.

   