### PR TITLE
Comment out harvest_source statistics

### DIFF
--- a/ckanext/harvest/logic/dictization.py
+++ b/ckanext/harvest/logic/dictization.py
@@ -117,11 +117,14 @@ def _get_source_status(source, context):
 
     job_count = HarvestJob.filter(source=source).count()
 
+    # Overall statistics are commented out because of timeout issues
+    # an issue has been raised https://github.com/ckan/ckanext-harvest/issues/366
+    # for the CKAN team to look into
     out = {
         'job_count': 0,
         'next_harvest': '',
         'last_harvest_request': '',
-        'overall_statistics': {'added': 0, 'errors': 0},
+        # 'overall_statistics': {'added': 0, 'errors': 0},
         }
 
     if not job_count:
@@ -146,24 +149,24 @@ def _get_source_status(source, context):
         out['last_harvest_request'] = str(last_job.gather_finished)
 
         # Overall statistics
-        packages = model.Session.query(distinct(HarvestObject.package_id),
-                                       Package.name) \
-            .join(Package).join(HarvestSource) \
-            .filter(HarvestObject.source == source) \
-            .filter(
-            HarvestObject.current == True  # noqa: E711
-        ).filter(Package.state == u'active')
+        # packages = model.Session.query(distinct(HarvestObject.package_id),
+        #                                Package.name) \
+        #     .join(Package).join(HarvestSource) \
+        #     .filter(HarvestObject.source == source) \
+        #     .filter(
+        #     HarvestObject.current == True  # noqa: E711
+        # ).filter(Package.state == u'active')
 
-        out['overall_statistics']['added'] = packages.count()
+        # out['overall_statistics']['added'] = packages.count()
 
-        gather_errors = model.Session.query(HarvestGatherError) \
-            .join(HarvestJob).join(HarvestSource) \
-            .filter(HarvestJob.source == source).count()
+        # gather_errors = model.Session.query(HarvestGatherError) \
+        #     .join(HarvestJob).join(HarvestSource) \
+        #     .filter(HarvestJob.source == source).count()
 
-        object_errors = model.Session.query(HarvestObjectError) \
-            .join(HarvestObject).join(HarvestJob).join(HarvestSource) \
-            .filter(HarvestJob.source == source).count()
-        out['overall_statistics']['errors'] = gather_errors + object_errors
+        # object_errors = model.Session.query(HarvestObjectError) \
+        #     .join(HarvestObject).join(HarvestJob).join(HarvestSource) \
+        #     .filter(HarvestJob.source == source).count()
+        # out['overall_statistics']['errors'] = gather_errors + object_errors
     else:
         out['last_harvest_request'] = 'Not yet harvested'
 


### PR DESCRIPTION
## What 

The queries to retrieve statistics for harvest sources are causing time out issues which is affecting UKMDE users from running its harvest. 

An issue has been raised on github https://github.com/ckan/ckanext-harvest/issues/366, for the CKAN team to look into but in the meantime as the stats are not needed by UKMDE the statistics queries are commented out so that they can start harvesting.