### PR TITLE
Add force import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,6 +253,10 @@ The following operations can be run from the command line as described underneat
           import) without involving the web UI or the queue backends. This is
           useful for testing a harvester without having to fire up
           gather/fetch_consumer processes, as is done in production.
+          
+      harvester run_test {source-id/name} force-import=guid1,guid2...
+        - In order to force an import of particular datasets, useful to 
+          target a dataset for dev purposes or when forcing imports on other environments.
 
       harvester gather_consumer
         - starts the consumer for the gathering queue

--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -455,6 +455,9 @@ class Harvester(CkanCommand):
                 job_dict = jobs[0]
         job_obj = HarvestJob.get(job_dict['id'])
 
+        if len(self.args) >= 3 and self.args[2].startswith('force-import='):
+            job_obj.force_import = self.args[2].split('=')[-1]
+
         harvester = queue.get_harvester(source['source_type'])
         assert harvester, \
             'No harvester found for type: {0}'.format(source['source_type'])


### PR DESCRIPTION
## What

If a dataset has been created with incomplete or incorrect data, its not possible to reimport it without deleting the dataset and the harvest_object which will have to be done manually or by clearing the harvest source. 

This allows devs to target a dataset for import rather than having to wait for a harvest job to complete and will force an import of a dataset with specified guids even if the data has not been modified. 

This will be needed in order to reharvest datasets that do not have the WMS format set preventing previews - https://trello.com/c/bomJEEnz/1112-investigate-wms-map-preview-not-being-available-for-some-records