### PR TITLE
Switch args around for redis.lrem function

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -203,7 +203,7 @@ class RedisPublisher(object):
         value = json.dumps(body)
         # remove if already there
         if self.routing_key == get_gather_routing_key():
-            self.redis.lrem(self.routing_key, 0, value)
+            self.redis.lrem(self.routing_key, value, 0)
         self.redis.rpush(self.routing_key, value)
 
     def close(self):


### PR DESCRIPTION
## What

Reasons found here -
https://github.com/andymccurdy/redis-py/issues/678

To do with Redis vs StrictRedis