### PR TITLE
Handle both types of calls on redis.lrem

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -203,7 +203,13 @@ class RedisPublisher(object):
         value = json.dumps(body)
         # remove if already there
         if self.routing_key == get_gather_routing_key():
-            self.redis.lrem(self.routing_key, value, 0)
+            # it appears that both types of call are possible within the redis library depending on which version used
+            # for now support both versions
+            # https://github.com/andymccurdy/redis-py#client-classes-redis-and-strictredis
+            try:
+                self.redis.lrem(self.routing_key, 0, value)
+            except:
+                self.redis.lrem(self.routing_key, value, 0)
         self.redis.rpush(self.routing_key, value)
 
     def close(self):


### PR DESCRIPTION
## What

It turns out that the way the way that it is called is different on CKAN release 2.7.4 .

https://github.com/ckan/ckan/blob/20a506ddbce33c92e3dfc510e1f1d7097caa45f9/requirements.txt#L41

As we want to use the latest harvest commit, this code should make it backward compatible.