### PR TITLE
Allow filtering by organisation for harvest_source_list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -885,6 +885,21 @@ Here are some common errors and solutions:
 * ``(OperationalError) near "SET": syntax error``
   You are testing with SQLite as the database, but the CKAN Harvester needs PostgreSQL. Specify test-core.ini instead of test.ini.
 
+Harvest API
+=====
+
+ckanext-harvest has multiple API's exposed in the format `/api/action/<endpoint>`.
+
+* `/api/action/harvest_source_list`
+
+This endpoint will return all the harvest sources in CKAN with a default limit
+of 100 items. The limit can be set to a bespoke value in the config for ckan
+under `ckan.harvest.harvest_source_limit`.
+
+An optional query param `organization_id` can be used to narrow down the
+results to only return the harvest sources created by certain organization's by
+supplying their respective organization id -> `/api/action/harvest_source_list?organization_id=<some-org-id>`
+
 
 Releases
 ========

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -1,11 +1,13 @@
 import logging
+from ckan.lib.base import config
 from sqlalchemy import or_
-from ckan.model import User
+from ckan.model import User, Package
 import datetime
 
 from ckan import logic
 from ckan.plugins import PluginImplementations
 from ckanext.harvest.interfaces import IHarvester
+from ckan.common import request
 
 import ckan.plugins as p
 from ckan.logic import NotFound, check_access, side_effect_free
@@ -124,9 +126,10 @@ def harvest_source_list(context, data_dict):
     TODO: Use package search
     '''
 
-    check_access('harvest_source_list', context, data_dict)
+    organization_id = request.params.get('organization_id')
+    limit = config.get('ckan.harvest.harvest_source_limit', 100)
 
-    sources = _get_sources_for_user(context, data_dict)
+    sources = _get_sources_for_user(context, data_dict, organization_id=organization_id, limit=limit)
 
     last_job_status = p.toolkit.asbool(data_dict.get('return_last_job_status', False))
 
@@ -361,7 +364,7 @@ def harvest_log_list(context, data_dict):
     return out
 
 
-def _get_sources_for_user(context, data_dict):
+def _get_sources_for_user(context, data_dict, organization_id=None, limit=None):
 
     session = context['session']
     user = context.get('user', '')
@@ -371,6 +374,11 @@ def _get_sources_for_user(context, data_dict):
 
     query = session.query(HarvestSource) \
         .order_by(HarvestSource.created.desc())
+
+    if organization_id:
+        query = query.join(
+            Package, HarvestSource.id == Package.id
+        ).filter(Package.owner_org == organization_id)
 
     if only_active:
         query = query.filter(
@@ -406,6 +414,6 @@ def _get_sources_for_user(context, data_dict):
         log.debug('User %s with publishers %r has Harvest Sources: %r',
                   user, publishers_for_the_user, [(hs.id, hs.url) for hs in query])
 
-    sources = query.all()
+    sources = query.limit(limit).all() if limit else query.all()
 
     return sources


### PR DESCRIPTION
This commit allows users of the harvest_source_list endpoint to
return harvest sources by a specific organisation by using a query param
`organization_id`. Also this endpoint won't
return more than 100 harvest sources as we were having timing out issues
due to the amount being previously returned (500+).

I've also removed the check_access method as this currently wasn't doing
anything as you didn't need to be authorized to access this endpoint.

Trello:
https://trello.com/c/iAWEYNOv/1946-5-dgu-add-ability-for-harvestsourcelist-to-filter-by-organisation%F0%9F%8D%90

Zendesk:
https://govuk.zendesk.com/agent/tickets/4034244