### PR TITLE
Limit viewing harvest jobs to the most recent 10

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -239,7 +239,7 @@ def harvest_job_list(context, data_dict):
 
     query = query.order_by(HarvestJob.created.desc())
 
-    jobs = query.all()
+    jobs = query.limit(10).all()
 
     context['return_error_summary'] = False
     return [harvest_job_dictize(job, context) for job in jobs]
@@ -421,7 +421,7 @@ def _get_sources_for_user(context, data_dict, organization_id=None, limit=None):
 def harvest_get_notifications_recipients(context, data_dict):
     """ get all recipients for a harvest source
         Return a list of dicts like {'name': 'Jhon', 'email': jhon@source.com'} """
-    
+
     check_access('harvest_get_notifications_recipients', context, data_dict)
 
     source_id = data_dict['source_id']
@@ -457,5 +457,5 @@ def harvest_get_notifications_recipients(context, data_dict):
                     'name': member_details['name'],
                     'email': member_details['email']
                 })
-    
+
     return recipients

--- a/ckanext/harvest/templates/source/job/list.html
+++ b/ckanext/harvest/templates/source/job/list.html
@@ -11,6 +11,8 @@
   {% if jobs|length == 0 %}
     <p class="empty">{{ _('No jobs yet for this source') }}</p>
   {% else %}
+    <p>View the most recent 10 jobs below:</p>
+
     <ul class="dataset-list unstyled">
       {% for job in jobs %}
         <li class="dataset-item">


### PR DESCRIPTION
The query to get harvest jobs is quite expensive and also [involves making subsequent queries for each harvest job](https://github.com/ckan/ckanext-harvest/blob/8525767dac35fb4fbf5abd88c86c1d0b3aca195c/ckanext/harvest/logic/dictization.py#L29-L80). This means that the query can often take a long time to execute and often for some users they'll see the page timeout with a "504 Gateway Time-out" error. Ideally we would update the query to avoid N+1 problems, but this would require quite a significant refactor of the code and this immediate fix prevents users seeing errors.

Originally, the plan was to limit this to 100, but even that doesn't solve the problem, and only reducing it down to the most recent 10 jobs means users can see the page.

I'll write up a card after this to improve the performance of the query and then we can look at getting that merged in upstream.

[Trello Card](https://trello.com/c/SlEIlfPl/2149-8-restrict-number-of-jobs-shown-for-harvest-jobs-list-to-100)